### PR TITLE
add support for hostnames in config

### DIFF
--- a/src/server_config/config.rs
+++ b/src/server_config/config.rs
@@ -6,7 +6,7 @@ use crate::server::{cookie_demo, update_cookie, validate_cookie, Cgi};
 pub use crate::server_config::*;
 pub fn server_config() -> Vec<ServerConfig<'static>> {
     vec![ServerConfig {
-        host: "127.0.0.1",
+        host: "localhost",
         ports: vec![8080, 8081, 8082],
         default_error_path: Some("/files/default_errors"),
         body_size_limit: 1000000000024,

--- a/src/server_config/config.rs
+++ b/src/server_config/config.rs
@@ -6,7 +6,7 @@ use crate::server::{cookie_demo, update_cookie, validate_cookie, Cgi};
 pub use crate::server_config::*;
 pub fn server_config() -> Vec<ServerConfig<'static>> {
     vec![ServerConfig {
-        host: "localhost",
+        host: "127.0.0.1",
         ports: vec![8080, 8081, 8082],
         default_error_path: Some("/files/default_errors"),
         body_size_limit: 1000000000024,


### PR DESCRIPTION
If you edit ../etc/hosts file and add test.com 127.0.0.1

you can have test.com as a host

Move tests into own modules in all files

Add a static client for integration tests

add cookie demo frontend

main rebase cleanup

refactor unwrap in get fn to handle err from get_route