### PR TITLE
Add dynamic default error page

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub mod server_config {
     pub struct ServerConfig<'a> {
         pub host: &'a str,
         pub ports: Vec<Port>,
-        pub default_error_path: Option<Path<'a>>,
+        pub custom_error_path: Option<Path<'a>>,
         pub body_size_limit: usize,
         pub routes: Vec<Route<'a>>,
     }

--- a/src/server/responses.rs
+++ b/src/server/responses.rs
@@ -153,8 +153,43 @@ pub mod errors {
             .unwrap()
     }
 
+    fn generate_error_html(code: u16, name: &str) -> String {
+        format!(
+            r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{code} {name}</title>
+    <style>
+        body {{
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }}
+
+        h1 {{
+            text-align: center;
+            font-size: xxx-large;
+            font-family: sans-serif;
+        }}
+    </style>
+</head>
+<body>
+<h1>{code} | {name}</h1>
+</body>
+</html>"#,
+        )
+    }
+
     fn check_errors(code: StatusCode, config: &ServerConfig) -> std::io::Result<Bytes> {
-        let error_path = config.default_error_path.unwrap_or("/files/default_errors");
-        fs::read(format!(".{error_path}/{}.html", code.as_u16()))
+        if let Some(custom_error_path) = config.custom_error_path {
+            fs::read(format!(".{custom_error_path}/{}.html", code.as_u16()))
+        } else {
+            let name = code.canonical_reason().unwrap_or_default();
+            let code = code.as_u16();
+            Ok(Bytes::from(generate_error_html(code, name)))
+        }
     }
 }

--- a/src/server/start.rs
+++ b/src/server/start.rs
@@ -92,7 +92,7 @@ mod tests {
         let server_config = ServerConfig {
             host: "127.0.0.1",
             ports: vec![],
-            default_error_path: None,
+            custom_error_path: None,
             body_size_limit: 0,
             routes: vec![],
         };

--- a/src/server_config/config.rs
+++ b/src/server_config/config.rs
@@ -8,7 +8,7 @@ pub fn server_config() -> Vec<ServerConfig<'static>> {
     vec![ServerConfig {
         host: "127.0.0.1",
         ports: vec![8080, 8081, 8082],
-        default_error_path: Some("/files/default_errors"),
+        custom_error_path: None,
         body_size_limit: 1000000000024,
         routes: vec![
             Route {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -17,6 +17,8 @@ mod test_config {
 }
 mod test_handle_client {
     use lazy_static::lazy_static;
+    use std::thread;
+    use std::time::Duration;
     const HOST: &str = "http://127.0.0.1:8080";
     lazy_static! {
         static ref CLIENT: Client = Client::new();
@@ -111,6 +113,7 @@ mod test_handle_client {
         );
 
         assert!(resp.status().is_success());
+        thread::sleep(Duration::from_secs(1));
 
         // Attempt to get a cookie we don't have.
         let invalid_endpoint = "/api/get-cookie";

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -51,7 +51,7 @@ pub fn mock_server_config() -> ServerConfig<'static> {
     let config = ServerConfig {
         host: "127.0.0.1",
         ports: vec![8080],
-        default_error_path: None,
+        custom_error_path: None,
         body_size_limit: 10024,
         routes: vec![
             Route {


### PR DESCRIPTION
Change `default_error_path` to `custom_error_path` in `ServerConfig`

Add a slight timer for the handlers test. I think this was creating the issue with tests sometimes failing, and sometimes passing.